### PR TITLE
Expose the function to spawn invalidation on cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ const manager = fileManagement.create('S3', {
       .catch(console.error);
 ```
 
+#### Run cloudfront invalidation
+After `upload` function is executed, it exposes `invalidate` function along with the original upload result:
+```js
+manager.uploadFile(...args)
+.then(({ invalidate, result }) => {
+  console.log(result);
+  /*
+    paths and cloudfront distribution id
+    @param paths defaults to ['/*']
+    @param distribution can be set as CLOUDFRONT_DISTRIBUTION_ID env var
+   */
+  return invalidate(['/img/*', '123ABC456EFG'])
+})
+.then((invalidationResult) => {
+  console.log(invalidationResult);
+});
+```
+
 #### Download (Downloads a file from storage)
 ```js
 const fileManagement = require('file-management');

--- a/README.md
+++ b/README.md
@@ -44,21 +44,26 @@ const manager = fileManagement.create('S3', {
 ```
 
 #### Run cloudfront invalidation
-After `upload` function is executed, it exposes `invalidate` function along with the original upload result:
 ```js
-manager.uploadFile(...args)
-.then(({ invalidate, result }) => {
-  console.log(result);
-  /*
-    paths and cloudfront distribution id
-    @param paths defaults to ['/*']
-    @param distribution can be set as CLOUDFRONT_DISTRIBUTION_ID env var
-   */
-  return invalidate(['/img/*', '123ABC456EFG'])
-})
-.then((invalidationResult) => {
-  console.log(invalidationResult);
+const fileManagement = require('file-management');
+const manager = fileManagement.create('S3', {
+  auth: {
+    // AWS creds need to be provided
+    AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+    AWS_REGION: process.env.AWS_REGION,
+  },
+  // s3 options as needed
+  options: {}
 });
+
+const invalidationPaths = ['/css/*', '/img/*']; // ['/*'] by default
+const distributionId = '123ABC456EFG' || process.env.CLOUDFRONT_DISTRIBUTION_ID;
+
+manager.invalidate(invalidationPaths, distributionId)
+  .then((result) => {
+    console.log(result);
+  });
 ```
 
 #### Download (Downloads a file from storage)

--- a/src/index.js
+++ b/src/index.js
@@ -10,44 +10,7 @@ const defaultConfig = require('./providers/config').create();
  */
 module.exports.create = (provider = 'default', config = defaultConfig) => {
   assert(provider, 'A provider must be specified');
-  const activeProvider = providerFactory.createProvider(provider, Object.assign({ options: {} }, config));
-  /**
-   *@class FileManager
-   */
-  return {
-    /**
-     * Download a file using a provider
-     * @method downloadFile
-     * @name downloadFile
-     * @param args
-     * @return {Promise}
-     */
-    downloadFile(...args) {
-      return activeProvider.downloadFile(...args);
-    },
-
-    /**
-     * Upload a file using a provider
-     * @method
-     * @name uploadFile
-     * @param args
-     * @return {Promise}
-     */
-    uploadFile(...args) {
-      return activeProvider.uploadFile(...args);
-    },
-
-    /**
-     * Delete a file using a provider
-     * @method
-     * @name deleteFile
-     * @param args
-     * @return {Promise}
-     */
-    deleteFile(...args) {
-      return activeProvider.deleteFile(...args);
-    }
-  };
+  return providerFactory.createProvider(provider, Object.assign({ options: {} }, config));
 };
 
 module.exports.providers = providerFactory.providers;

--- a/src/providers/s3.js
+++ b/src/providers/s3.js
@@ -1,7 +1,7 @@
 const S3 = require('aws-sdk/clients/s3');
 const Cloudfront = require('aws-sdk/clients/cloudfront');
 const assert = require('assert');
-const BaseProvider = require('./base');
+const BaseProvider = require('./base.js');
 
 const s3 = Symbol('s3');
 const cloudFront = Symbol('cloudFront');
@@ -33,6 +33,15 @@ class S3Provider extends BaseProvider {
     this.invalidate = this.invalidate.bind(this);
   }
 
+  /**
+    * Download a file using an s3 provider
+    * @method downloadFile
+    * @name downloadFile
+    * @param location {string} - s3 bucket name
+    * @param uploadName {string} - file name that will be downloaded
+    * @param writableStream {Stream} - writable file stream
+    * @return {Promise}
+  */
   downloadFile(location, uploadName, writableStream) {
     return new Promise((resolve, reject) => {
       assert(location, 'location of the upload needs to be provided');
@@ -54,6 +63,15 @@ class S3Provider extends BaseProvider {
     });
   }
 
+  /**
+    * Upload a file using an s3
+    * @method
+    * @name uploadFile
+    * @param location {string} - s3 bucket name
+    * @param uploadName {string} - file name that will be uploaded
+    * @param writableStream {Stream} - readable file stream
+    * @return {Promise}
+  */
   uploadFile(location, uploadName, fileStream) {
     return new Promise((resolve, reject) => {
       assert(location, 'location of the upload needs to be provided');
@@ -74,23 +92,29 @@ class S3Provider extends BaseProvider {
         if (err) {
           return reject(err);
         }
-        return resolve({
-          invalidate: this.invalidate,
-          result
-        });
+        return resolve(result);
       });
     });
   }
 
+  /**
+    * Spawn invalidation of the file on cdn
+    * @method
+    * @name invalidate
+    * @param invalidationPaths {string} - paths that will be invalidated inside the distribution
+    * @param distribution {string} - ID of cloudfront distribution
+    * @return {Promise}
+  */
   invalidate(invalidationPaths = ['/*'], distribution = process.env.CLOUDFRONT_DISTRIBUTION_ID) {
     return new Promise((resolve, reject) => {
       assert(distribution, 'distribution has to be a non empty string');
+      const isArray = Array.isArray(invalidationPaths);
       assert(
         (invalidationPaths && typeof invalidationPaths === 'string')
-        || Array.isArray(invalidationPaths),
+        || isArray,
         'invalidationPaths must be a string or array of strings'
       );
-      const targetPaths = Array.isArray(invalidationPaths) ? invalidationPaths : [invalidationPaths];
+      const targetPaths = isArray ? invalidationPaths : [invalidationPaths];
       this[cloudFront].createInvalidation({
         DistributionId: distribution,
         InvalidationBatch: {
@@ -104,6 +128,14 @@ class S3Provider extends BaseProvider {
     });
   }
 
+  /**
+    * Delete a file using a provider
+    * @method
+    * @name deleteFile
+    * @param location {string} - s3 bucket name
+    * @param uploadName {string} - file name that will be deleted
+    * @return {Promise}
+  */
   deleteFile(location, uploadName) {
     return new Promise((resolve, reject) => {
       assert(location, 'location of the upload needs to be provided');

--- a/test/intergration/provider-s3.js
+++ b/test/intergration/provider-s3.js
@@ -18,7 +18,7 @@ describe('S3 Provider', () => {
       auth: {
         AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
         AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
-        AWS_REGION: process.env.AWS_REGION,
+        AWS_REGION: process.env.AWS_REGION
       },
       options: {}
     });

--- a/test/intergration/provider-s3.js
+++ b/test/intergration/provider-s3.js
@@ -26,6 +26,7 @@ describe('S3 Provider', () => {
     expect(manager).to.be.an('Object').and.to.be.ok;
     expect(manager.downloadFile).to.be.a('Function').and.to.be.ok;
     expect(manager.uploadFile).to.be.a('Function').and.to.be.ok;
+    expect(manager.invalidate).to.be.a('Function').and.to.be.ok;
     expect(manager.deleteFile).to.be.a('Function').and.to.be.ok;
 
     const testFileName = 'test-LICENSE';
@@ -35,7 +36,7 @@ describe('S3 Provider', () => {
       const stream = fs.createReadStream('./LICENSE');
       return manager
         .uploadFile(testLocation, testFileName, stream)
-        .then(({ result }) => {
+        .then((result) => {
           expect(result).to.be.an('object').and.to.be.ok;
           expect(result.Location).to.be.a('String')
             .and.to.include(testFileName)
@@ -44,20 +45,11 @@ describe('S3 Provider', () => {
         });
     });
 
-    it('to expose the function to run invalidation after upload', () => {
-      const stream = fs.createReadStream('./LICENSE');
-      return manager
-        .uploadFile(testLocation, testFileName, stream)
-        .then((result) => {
-          expect(result.invalidate).to.be.a('function');
-          expect(result.result).to.be.an('object').and.to.be.ok;
-          return result.invalidate();
-        })
-        .then((result) => {
-          expect(result).to.be.an('object').and.to.be.ok;
-          expect(result.Invalidation).to.be.an('object');
-        });
-    });
+    it('to run invalidation', () => manager.invalidate().then((result) => {
+      expect(result).to.be.an('object').and.to.be.ok;
+      expect(result.Location).to.be.a('string').and.to.be.ok;
+      expect(result.Invalidation).to.be.an('object').and.to.be.ok;
+    }));
 
     it('to download a file', () => {
       const stream = fs.createWriteStream(testFileName);


### PR DESCRIPTION
I think that this is the only way to do this and not end up refactoring the whole project.
Since everything is bound and is made private, I can not expose the invalidation function, because it is non standard and might be AWS specific (so there might be no reason in exposing it in the `index.js` file.